### PR TITLE
Remove deprecated C-API macro

### DIFF
--- a/SWIGWrappers/THyPhy_py3.cpp
+++ b/SWIGWrappers/THyPhy_py3.cpp
@@ -3216,7 +3216,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
 
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
-  _PyObject_GC_UNTRACK(descr);
+  PyObject_GC_UnTrack(descr);
   Py_XDECREF(PyDescr_TYPE(descr));
   Py_XDECREF(PyDescr_NAME(descr));
   PyObject_GC_Del(descr);

--- a/SWIGWrappers/THyPhy_python.cpp
+++ b/SWIGWrappers/THyPhy_python.cpp
@@ -3216,7 +3216,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
 
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
-  _PyObject_GC_UNTRACK(descr);
+  PyObject_GC_UnTrack(descr);
   Py_XDECREF(PyDescr_TYPE(descr));
   Py_XDECREF(PyDescr_NAME(descr));
   PyObject_GC_Del(descr);

--- a/hyphy-src/src/lib/SWIGWrappers/THyPhy_py3.cpp
+++ b/hyphy-src/src/lib/SWIGWrappers/THyPhy_py3.cpp
@@ -3216,7 +3216,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
 
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
-  _PyObject_GC_UNTRACK(descr);
+  PyObject_GC_Untrack(descr)
   Py_XDECREF(PyDescr_TYPE(descr));
   Py_XDECREF(PyDescr_NAME(descr));
   PyObject_GC_Del(descr);

--- a/hyphy-src/src/lib/SWIGWrappers/THyPhy_python.cpp
+++ b/hyphy-src/src/lib/SWIGWrappers/THyPhy_python.cpp
@@ -3216,7 +3216,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
 
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
-  _PyObject_GC_UNTRACK(descr);
+  PyObject_GC_UnTrack(descr);
   Py_XDECREF(PyDescr_TYPE(descr));
   Py_XDECREF(PyDescr_NAME(descr));
   PyObject_GC_Del(descr);


### PR DESCRIPTION
This commit replaces use of the deprecated [`_PyOjbect_GC_UNTRACK`](https://docs.python.org/3.7/c-api/gcsupport.html#c._PyObject_GC_UNTRACK) macro with calls to the equivalent
[`PyObject_GC_UnTrack`](https://docs.python.org/3.7/c-api/gcsupport.html#c.PyObject_GC_UnTrack) function.

This change is required to support Python 3.8, which removes the
deprecated macro.